### PR TITLE
Remove unused packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,11 @@
   "author": "Vlad Stirbu <vstirbu@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.2.0",
-    "mongoose": "^4.6.1",
-    "mongoose-schema-extend": "^0.2.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "express": "^4.14.0",
-    "mocha": "^3.1.0"
+    "mocha": "^3.1.0",
+    "mongoose": "^4.6.1"
   }
 }


### PR DESCRIPTION
Both `debug` and `mongoose-schema-extend` aren't used and `mongoose` is actually only used as a dev dependency.