### PR TITLE
Add ObjectIds to JSON schema exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,10 @@ function modelToJSONSchema(model, options) {
   'use strict';
   
   var schema =  model.schema,
-      reserved = ['_id', '__v'],
+      reserved = {
+        '_id': true,
+        '__v': true
+      },
       result = {
         $schema: 'http://json-schema.org/schema#',
         title: model.modelName,
@@ -20,7 +23,13 @@ function modelToJSONSchema(model, options) {
   options = options || {};
       
   if (options.reserved) {
-    reserved = reserved.concat(options.reserved);
+    if(Array.isArray(options.reserved)){
+      options.reserved.forEach(function(r){
+        reserved[r] = true;
+      });      
+    }else{
+      reserved = Object.assign(reserved, options.reserved);
+    }
   }
   
   if (result.required.length === 0) {
@@ -28,7 +37,7 @@ function modelToJSONSchema(model, options) {
   }
   
   schema.eachPath(function (path) {
-    if (reserved.indexOf(path) === -1) {
+    if (!reserved[path]) {
       var property = {};
 
       var frags = path.split('.'),
@@ -47,6 +56,9 @@ function modelToJSONSchema(model, options) {
         case 'Date':
           property.type = 'string';
           property.format = 'date-time';
+          break;
+        case 'ObjectId':
+          property.type = 'string';
           break;
         default:
           // typed array

--- a/test/index.js
+++ b/test/index.js
@@ -56,4 +56,25 @@ describe('modelToJSONSchema', function () {
     expect(jsonSchema.properties.root.properties.nestedProp).to.exist;
     expect(jsonSchema.properties.root.required).to.be.deep.equal(['nestedProp']);
   });
+  
+  describe('options', function(){
+    describe('reserved', function(){
+      it('should filter out fields provided as an array', function(){
+        var jsonSchema = lib.modelToJSONSchema(mongoose.model('Types'), {
+          reserved: ['stringProp']
+        });
+        expect(jsonSchema.properties.stringProp).to.be.undefined;
+      });
+      it('should filter out fields as defined in a flag map', function(){
+        var jsonSchema = lib.modelToJSONSchema(mongoose.model('Types'), {
+          reserved: {
+            stringProp: true,
+            _id: false
+          }
+        });
+        expect(jsonSchema.properties.stringProp).to.be.undefined;
+        expect(jsonSchema.properties._id).to.exist;
+      });
+    })
+  });
 });


### PR DESCRIPTION
I added the possibility to export ObjectIds naively, i.e. they're exported as strings. Obviously this means all `_id` fields will be exported by default too.
This can be turned off by passing `{reserved:['_id']}`

If you'd rather have this the other way around, i.e. a opt-in rather than opt-out, let me know.