### PR TITLE
Cache path options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,15 +34,15 @@ function modelToJSONSchema(model, options) {
       var frags = path.split('.'),
           name = frags.pop();
           
-      //console.log(name, frags);
+      var pathOptions = schema.path(path).options;
 
-      switch (schema.path(path).options.type.name) {
+      switch (pathOptions.type.name) {
         case 'Array': // untyped array
         case 'Boolean':
         case 'Number':
         case 'Object':
         case 'String':
-          property.type = schema.path(path).options.type.name.toLowerCase();
+          property.type = pathOptions.type.name.toLowerCase();
           break;
         case 'Date':
           property.type = 'string';
@@ -50,7 +50,7 @@ function modelToJSONSchema(model, options) {
           break;
         default:
           // typed array
-          if (Array.isArray(schema.path(path).options.type)) {
+          if (Array.isArray(pathOptions.type)) {
             property.type = 'array';
             property.items = {
               type: schema.path(path).casterConstructor.name.toLowerCase()
@@ -58,12 +58,12 @@ function modelToJSONSchema(model, options) {
           }
       }
 
-      if (schema.path(path).options.enum) {
-        property.enum = schema.path(path).options.enum;
+      if (pathOptions.enum) {
+        property.enum = pathOptions.enum;
       }
       
-      if (schema.path(path).options.default) {
-        property.default = schema.path(path).options.default;
+      if (pathOptions.default) {
+        property.default = pathOptions.default;
       }
 
       //console.log(schema.path(path));


### PR DESCRIPTION
Minor improvement by caching `schema.path(path).options` into a `pathOptions` var.